### PR TITLE
Add validation for minimum volunteers needed

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ActiveRecord::Base
   belongs_to :organization
   validates_presence_of :title, :description, :organization, :start_date, :end_date, :map, :volunteers_needed
   validates_presence_of :categories, :event_types
+  validates_numericality_of :volunteers_needed, :greater_than => 0
   has_many :participations
   has_many :volunteers, :source => :user, :through => :participations
   scope :upcoming, lambda { where("end_date >= ?", Date.today).limit(8) }


### PR DESCRIPTION
Don't allow users to input 0 as number of volunteers needed.
