### PR TITLE
add : on the labels for now to fix the tests

### DIFF
--- a/app/views/layouts/_member_area.html.haml
+++ b/app/views/layouts/_member_area.html.haml
@@ -18,11 +18,11 @@
     = form_for("user", :url => user_session_path) do |f|
       %h2 Member's Corner
       .member_input
-        = f.label :email, :for => "user_email_top"
+        = f.label :email, "Email:", :for => "user_email_top"
         %br/
         = f.text_field :email, :align => "top", :size => nil, :id => "user_email_top"
       .member_input
-        = f.label :password, :for => "user_password_top"
+        = f.label :password, "Password:", :for => "user_password_top"
         %br/
         = f.password_field :password, :align => "top", :size => nil, :id => "user_password_top"
         %br/


### PR DESCRIPTION
This fixes our tests. One of the errors can be seen below. Basically, signup doesn't work because cucumber inputs the email and password on the top of the page instead of the registration form.

Our tests are brittle. I created these tests, and I would like to hear suggestions.

Using Email: (with colon) fixes the issue since the registration form uses Email (without colon).

cenario: Organization admin creates an event              # features/event.feature:6
    Given I am logged in                                     # features/step_definitions/login_and_registration_steps.rb:5
    And an organization exists with a name of "DSWD"         # factory_girl-2.6.0/lib/factory_girl/step_definitions.rb:119
    And a category exists with a name of "Education"         # factory_girl-2.6.0/lib/factory_girl/step_definitions.rb:119
    And an event type exists with a name of "IT Development" # factory_girl-2.6.0/lib/factory_girl/step_definitions.rb:119
    And the following organization role exists:              # factory_girl-2.6.0/lib/factory_girl/step_definitions.rb:100
      | User                          | Organization | Role  |
      | Email: test@ivolunteer.com.ph | Name: DSWD   | owner |
      Validation failed: First name can't be blank, Middle name can't be blank, Last name can't be blank, Mobile number can't be blank, Mobile number should be a valid number, Gender can't be blank, Date of birth can't be blank, Country can't be blank, City can't be blank, Nationality can't be blank, Expertises can't be blank (ActiveRecord::RecordInvalid)
      features/event.feature:11:in `And the following organization role exists:'
