### PR TITLE
Remove sign in link from forgot password.

### DIFF
--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to "Sign in", new_session_path(resource_name)
+  =# link_to "Sign in", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "Sign up", new_registration_path(resource_name)


### PR DESCRIPTION
Sign in link should not show up in the forgot password page.
